### PR TITLE
removed leftover TODO note from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ reveal(gutMensch, "Chrome Boi")
 
 If we were to first pre-digest our files with Webpack, we would instead have a single, all-encompassing, file that ensures our dependencies are right where they belong.
 
-TODO: removed the code along/named export part that was here (see curriculum/react-jsx repo). Check lab and put there? Don't want to reincorporate: long enough as it is.
 
 ## Summary
 


### PR DESCRIPTION
removed leftover TODO note from readme

This should also be changed from a lab to a readme, but I'm not sure how to fix that :)